### PR TITLE
Group contentgrid npm packages into one update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,14 @@
       ],
       "separateMinorMajor": false,
       "automerge": false
+    },
+    {
+      "description": "Group all contentgrid npm package updates",
+      "groupName": "contentgrid-monorepo",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchSourceUrl": "https://github.com/xenit-eu/contentgrid-ts"
     }
   ]
 }


### PR DESCRIPTION
The packages in `@contentgrid/*` have interdependencies and are developed in a monorepo.
Not updating them together sometimes causes issues, like these: https://github.com/xenit-eu/contentgrid-navigator/pull/1013 & https://github.com/xenit-eu/contentgrid-navigator/pull/1014 failing to build when both are updated separately. It would work properly when both were updated at the same time.