### PR TITLE
ACC-2016: group contentgrid gradle dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,7 +56,7 @@
       ]
     },
     {
-      "description": "Group all contentgrid gralde package updates",
+      "description": "Group all contentgrid gradle package updates",
       "groupName": "contentgrid-gradle-monorepo",
       "matchManagers": [
         "gradle"

--- a/renovate.json
+++ b/renovate.json
@@ -37,13 +37,32 @@
     },
     {
       "description": "Group all contentgrid npm package updates",
-      "groupName": "contentgrid-monorepo",
+      "groupName": "contentgrid-npm-monorepo",
       "matchManagers": [
         "npm"
       ],
       "matchSourceUrls": [
-        "https://github.com/xenit-eu/contentgrid-ts",
+        "https://github.com/xenit-eu/contentgrid-ts"
+      ]
+    },
+    {
+      "description": "Group all contentgrid pip package updates",
+      "groupName": "contentgrid-pip-monorepo",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchSourceUrls": [
         "https://github.com/xenit-eu/contentgrid-python-client"
+      ]
+    },
+    {
+      "description": "Group all contentgrid gralde package updates",
+      "groupName": "contentgrid-gradle-monorepo",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchSourceUrls": [
+        "https://github.com/xenit-eu/helm-integration-testing"
       ]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,8 @@
         "gradle"
       ],
       "matchSourceUrls": [
-        "https://github.com/xenit-eu/helm-integration-testing"
+        "https://github.com/xenit-eu/helm-integration-testing",
+        "https://github.com/xenit-eu/contentgrid-spring"
       ]
     }
   ]


### PR DESCRIPTION
Split out contentgrid-monorepo group into a group for npm, a group for pip and a group for gradle updates.