### PR TITLE
chore: hold early dependency PRs (internalChecksFilter) + auto-dedupe pnpm lockfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   ],
   "minimumReleaseAge": "14 days",
   "minimumReleaseAgeBehaviour": "timestamp-required",
+  "internalChecksFilter": "strict",
+  "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
       "description": "Auto-merge minor/patch updates",


### PR DESCRIPTION
## Summary

Two recurring problems in repos that extend this preset both trace back to it. This PR fixes both conservatively, without touching `minimumReleaseAge` or any existing `packageRules`.

---

### 1. `internalChecksFilter: "strict"` — suppress born-red pending PRs

**The problem.** The preset already sets `minimumReleaseAge: "14 days"`, which is correct. However, Renovate's *default* `internalChecksFilter` value is `"none"`, which means Renovate still **opens a PR** for a version that is inside the 14-day window — it just marks the PR as "pending" and shows a yellow warning. In pnpm repos that use `--frozen-lockfile` in CI, this is immediately fatal: pnpm's own `minimumReleaseAge` enforcement blocks the lockfile regeneration until the package ages past the window, so every such PR is born red on the `pnpm install --frozen-lockfile` gate.

**The fix.** `internalChecksFilter: "strict"` makes Renovate **withhold** the update entirely (shown on the Dependency Dashboard as "Not ready") until the age check passes. The PR is only opened once the version is at least 14 days old and the lockfile can be regenerated cleanly.

**What is NOT affected:**
- Security/vulnerability updates — they bypass `minimumReleaseAge` by design and still flow immediately.
- The existing `xenit-eu/*` and `docker.xenit.eu/**` / `ghcr.io/xenit-eu/*` `packageRules` that already set `minimumReleaseAge: "0 days"` — those 0-day overrides still apply; `strict` withholds only when the age check would fail.
- The 14-day window itself is unchanged.

**Blast radius.** This preset is extended by 46 xenit-eu repos. None of them currently set `internalChecksFilter`, so this adds the key at the shared level for all of them.

---

### 2. `postUpdateOptions: ["pnpmDedupe"]` — prevent split-lockfile incidents

**The problem.** When Renovate does a lockfile-only update in a pnpm monorepo, a transitive peer can pin an older version of a package, leaving two copies of the same dependency in `pnpm-lock.yaml`. Concrete incident: `contentgrid-navigator-horizon` PR #118 (a react-monorepo bump) ended up with both `react@19.2.6` and `react@19.2.7` in the lockfile because `@tanstack/react-query` had a peer that held the old version. React's strict singleton assumption then caused the test/coverage run to crash.

**The fix.** `postUpdateOptions: ["pnpmDedupe"]` instructs Renovate to run `pnpm dedupe` after every pnpm lockfile update, collapsing duplicate transitive versions before the PR is opened. The lockfile shipped in the PR is always deduplicated.

**What is NOT affected:**
- This option is silently ignored for non-pnpm package managers (gradle, pip_requirements, docker, helm). The 46-repo blast radius includes many Java/Python/Docker repos — adding this at the shared level is a NO-OP for all of them.
- No changes to update frequency, grouping, or automerge rules.

---

## Checklist

- [x] Both changes are additive / conservative — they make Renovate do less work prematurely, not more.
- [x] `renovate.json` validates as valid JSON (`python3 -c "import json; json.load(open('renovate.json')); print('valid')"` → `valid`).
- [x] `minimumReleaseAge`, `minimumReleaseAgeBehaviour`, and all `packageRules` are untouched.
- [x] The 0-day xenit-eu overrides continue to work correctly with `internalChecksFilter: "strict"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2gPDDGZ98bz5z4HXYbfxm